### PR TITLE
Generalize lifetime stuff into phx::ResourceKeeper

### DIFF
--- a/include/lifetime.hpp
+++ b/include/lifetime.hpp
@@ -1,0 +1,24 @@
+#ifndef PHX_LIFETIME_HPP
+#define PHX_LIFETIME_HPP
+
+#include <memory>
+#include <type_traits>
+
+namespace phx {
+
+    template <typename Resource, auto Destroyer>
+    struct ResourceKeeper
+        : public std::unique_ptr<Resource, decltype(Destroyer)> {
+
+	static_assert(
+	  std::is_invocable_v<decltype(Destroyer), Resource*>,
+	  "Destroyer must be invocable on Resource*");
+
+	ResourceKeeper(Resource* r) : unique_ptr(r, Destroyer) {}
+
+	operator Resource*() const { return get(); }
+    };
+
+} // namespace phx
+
+#endif // PHX_LIFETIME_HPP

--- a/include/phx_sdl/sdl_util.hpp
+++ b/include/phx_sdl/sdl_util.hpp
@@ -20,6 +20,8 @@ namespace phx_sdl {
 	        std::function<void()> postHooks =
 	          Helper::noop) noexcept(false);
 
+	SDLUtil(SDLUtil&&) = default;
+
 	int w() { return display.w(); }
 	int h() { return display.h(); }
 

--- a/include/phx_sdl/window.hpp
+++ b/include/phx_sdl/window.hpp
@@ -1,26 +1,39 @@
 #ifndef PHX_SDL_WINDOW_H
 #define PHX_SDL_WINDOW_H
 
+#include <string>
+
+#include "lifetime.hpp"
+
 #include "SDL.h"
 
 namespace phx_sdl {
 
+    namespace {
+
+	void destroy(SDL_Window*);
+
+	using WindowKeeper = phx::ResourceKeeper<SDL_Window, destroy>;
+
+    } // namespace
+
     class Window {
     public:
-	Window(const char* title = "Phoenix app",
+	Window(std::string title = "Phoenix app",
 	       int         x     = SDL_WINDOWPOS_CENTERED,
 	       int y = SDL_WINDOWPOS_CENTERED, int w = 640, int h = 480,
 	       Uint32 flags = 0) noexcept(false);
 
-	SDL_Window* handle() const;
+	Window(Window&&) = default;
+
+	operator SDL_Window*() const;
 
 	void        show();
 	const char* get_title() const;
 
-	~Window();
-
     private:
-	SDL_Window* window;
+	WindowKeeper window;
+
 	std::string title;
     };
 

--- a/src/sdl/window/window.cxx
+++ b/src/sdl/window/window.cxx
@@ -1,30 +1,33 @@
-#include <iostream>
+#include "phx_sdl/window.hpp"
+#include "init_error.hpp"
+#include "sdl_init_error.hpp"
 
 #include "SDL.h"
 
-#include "init_error.hpp"
-#include "phx_sdl/window.hpp"
-#include "sdl_init_error.hpp"
-
 namespace phx_sdl {
 
-    Window::Window(const char* title, int x, int y, int w, int h,
+    namespace {
+
+	void destroy(SDL_Window* w) {
+	    SDL_DestroyWindow(w);
+	    SDL_Quit();
+	}
+
+    } // namespace
+
+    Window::Window(std::string title, int x, int y, int w, int h,
                    Uint32 flags) noexcept(false)
         : title(title),
-          window(SDL_CreateWindow(title, x, y, w, h, flags)) {
-	if (window == NULL) {
+          window(SDL_CreateWindow(title.c_str(), x, y, w, h, flags)) {
+	if (window == nullptr) {
 	    throw phx_err::SDLInitError("SDL_CreateWindow failed");
 	}
     }
 
-    SDL_Window* Window::handle() const { return window; }
+    Window::operator SDL_Window*() const { return window; }
+
     const char* Window::get_title() const { return title.c_str(); }
 
     void Window::show() { SDL_ShowWindow(window); }
-
-    Window::~Window() {
-	SDL_DestroyWindow(window);
-	SDL_Quit();
-    }
 
 }; // namespace phx_sdl


### PR DESCRIPTION
This replaces the hacky `unique_ptr` in `VKRenderer`.